### PR TITLE
GCC colourization fix and conf files for `mount' and `df'

### DIFF
--- a/conf.df
+++ b/conf.df
@@ -1,0 +1,5 @@
+regexp=^((rootfs|tmpfs|udev)|(.*))\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+%)\s+(\S+)$
+colours=default,default,cyan,green,magenta,default,default,blue,yellow
+-
+regexp=100%|9\d%
+colours=red

--- a/conf.gcc
+++ b/conf.gcc
@@ -20,7 +20,7 @@ regexp=\-O\d
 colours=green
 .........
 # -o
-regexp=\-o\s.+\b
+regexp=\-o\s[^\s]+
 colours=yellow
 .........
 # warning and error won't work, unless you redirect also

--- a/conf.mount
+++ b/conf.mount
@@ -1,0 +1,2 @@
+regexp=^(.*) on (.*) type (.*) \((.*)\)
+colours=default,green,yellow,blue,magenta

--- a/grc.conf
+++ b/grc.conf
@@ -53,3 +53,7 @@ conf.cvs
 # mount
 (^|[/\w\.]+/)mount\s?
 conf.mount
+
+# df
+(^|[/\w\.]+/)df\s?
+conf.df

--- a/grc.conf
+++ b/grc.conf
@@ -49,3 +49,7 @@ conf.ldap
 # cvs command
 (^|[/\w\.]+/)cvs\s?
 conf.cvs
+
+# mount
+(^|[/\w\.]+/)mount\s?
+conf.mount


### PR DESCRIPTION
Hello,
 I've tried to contact the original author but unfortunately I did not get any answer. :(

Since yours is the main repo on GitHub I'd like to hear your opinion on pulling the following fixes and improvements:
- `mount` colourization
- `df` colourization
- fix `gcc` colourization of the `-o` option from spilling to the whole line

Let me know what you think about them.

Thanks!
